### PR TITLE
decorators and mixins pass the class they are changing

### DIFF
--- a/src/fiber.js
+++ b/src/fiber.js
@@ -200,7 +200,7 @@
     Fiber.decorate = function (instance /*, decorator[s] */) {
       var i,
         // Get the base prototype.
-        base = instance.constructor.__base__,
+        base = instance.constructor.prototype,
         // Get all the decorators in the arguments.
         decorators = ArrayProto.slice.call(arguments, 1),
         len = decorators.length;
@@ -246,7 +246,7 @@
     Fiber.mixin = function (definition /*, mixin[s] */) {
       var i,
         // Get the base prototype.
-        base = definition.__base__,
+        base = definition.prototype,
         // Get all the mixins in the arguments.
         mixins = ArrayProto.slice.call(arguments, 1),
         len = mixins.length;


### PR DESCRIPTION
In the current implementation, when you write a decorator like...

``` javascript
var MyDecorator = function(base) {
  return { /* stuff */  };
};
```

...the `base` argument is the `base` of the instance's `constructor`. Based on the `extend` functionality, I expected that `base` would be the class being decorated. This would be useful when you want to use a decorator that might be overriding an existing method that you still want.

This is how I expected to be able to use it...

``` javascript
var MyClass = Fiber.extend(function(base) {
  return {
    reallyCoolMethod: function() { /* cool stuff */ }
  };
});

var MyDecorator = function(base) {
  return {
    reallyCoolMethod: function() {
      // more betterer cool stuff
      base.reallyCoolMethod.apply(this, arguments); // or preferably - base.reallyCoolMethod()
    }
  };
}
```
