### PR TITLE
Adding bower support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
   "ignore": [
     "**/.*",
     "docs",
-    "tests",
+    "test",
     "package.json",
     "*.html"
   ]


### PR DESCRIPTION
I would like to add bower support for Fiber. Technically, no changes are needed, but the bower manifest file provides helpful information (primarily version number), and cleans up the files that are downloaded into the bower_components directory of a project.
### A note on testing

I've tested that the bower manifest produces the desired results. Results can be tested with `bower install fiber-one`, which points at my fork of the repo (neborn/Fiber). Just 'fiber' has already been registered for this repo (linkedin/Fiber), and can use `bower install fiber` to observe the result without the manifest file.

Thank you for your consideration.
